### PR TITLE
ENGREQ-5753: Make image docker:latest to auto get dependency updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:stable
+FROM docker:latest
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
This action is only used in codereview so if an issue arises because of auto-updating the docker image, it won't affect customers. Thus to avoid toil I'm setting it to latest instead of pinning a version.

If we see actual breakages occur due to the auto-updating we can reconsider.

Testing:
Verify the code review on https://github.com/infoseci/securityiq-deployment/pull/930 passes